### PR TITLE
Various optimizations and tweaks

### DIFF
--- a/client_firmware/client_firmware.ino
+++ b/client_firmware/client_firmware.ino
@@ -110,6 +110,8 @@ void setup () {
   // We already got the state from above. Setup the next issue.
   sync_timer = millis();
 
+  Ethernet::enableBroadcast();
+  Ethernet::enableMulticast();
 }
 
 void loop () {

--- a/client_firmware/client_firmware.ino
+++ b/client_firmware/client_firmware.ino
@@ -38,7 +38,6 @@
   (byte & 0x04 ? 1 : 0), \
   (byte & 0x02 ? 1 : 0), \
   (byte & 0x01 ? 1 : 0)
-#define STATE_ADDR 1
 
 const uint8_t my_mac[] = {
   0x74,0x69,0x69,0x2D,0x30,MY_ID };
@@ -141,6 +140,7 @@ void loop () {
       // Start looking for new target_ip; the DHCP reservation might time out
       // and the device get a new address next time.
       memcpy(target_ip, allOnes, sizeof target_ip);
+      saveStateToEeprom();
     }
   }
 

--- a/client_firmware/client_firmware.ino
+++ b/client_firmware/client_firmware.ino
@@ -8,7 +8,7 @@
 #define MINUTES (60 * SECONDS)
 #define HOURS (60 * MINUTES)
 // NOTE: All of these timers are in Milliseconds!
-// Ping our target every 2 seconds
+// Ping our target every 2 seconds, if we haven't seen traffic from it
 #define PINGER_INTERVAL (2 * SECONDS)
 // If target IP isn't known, ping sweep this often
 #define PINGSWEEP_INTERVAL_FIND_TARGET (1 * MINUTES)
@@ -102,7 +102,7 @@ void setup () {
   Serial.println(F("Now entering main loop\n"));
 
   // Setup timers
-  pinger_timer = millis() - PINGER_INTERVAL ;
+  pinger_timer = millis();
   // Start the absense timer with the total grace period to give it the benifit of the doubt
   absense_timer = millis();
   // We can start the ping sweep on bootup.
@@ -125,7 +125,8 @@ void loop () {
   // Ping our target to see if they are alive
   if (millis() > pinger_timer + PINGER_INTERVAL) {
     pinger_timer = millis();
-    ping_target();
+    if (millis() > absense_timer + PINGER_INTERVAL)
+      ping_target();
   }
 
   // If we haven't heard from our device, time to time out and turn off

--- a/client_firmware/rw_helpers.ino
+++ b/client_firmware/rw_helpers.ino
@@ -1,16 +1,147 @@
+#define DEBUG_EEPROM 0
+
+#include <util/crc16.h>
+
 // Read Write Helpers for eeprom management
 
-void saveStateToEeprom() {
-  cli();
-  if(EEPROM.read(STATE_ADDR) != state) {
-    EEPROM.write(STATE_ADDR, state);
+#define STATE_ADDR       0
+#define STATE_SIZE       1
+#define TARGET_IP_ADDR   (STATE_ADDR + STATE_SIZE)
+#define TARGET_IP_SIZE   4
+#define CHECKSUM_ADDR    (TARGET_IP_ADDR + TARGET_IP_SIZE)
+#define CHECKSUM_SIZE    2
+#define EEPROM_DATA_SIZE CHECKSUM_ADDR
+#define EEPROM_SIZE      (CHECKSUM_ADDR + CHECKSUM_SIZE)
+
+uint16_t crc_calc(const uint8_t *data, int len)
+{
+   uint16_t crc = 0;
+   int index;
+
+   for (index = 0; index < len; index++)
+      crc = _crc16_update(crc, data[index]);
+
+   return crc;
+}
+
+uint8_t crc_write(uint8_t *data, int len)
+{
+  uint16_t crc;
+
+  crc = crc_calc(data, len);
+#if DEBUG_EEPROM
+  {
+    char buf[5];
+
+    Serial.print(F("Recalc CRC: "));
+    sprintf(buf, "%04x", (unsigned int)crc);
+    Serial.println(buf);
   }
+#endif
+  data[len] = crc & 0xff;
+  data[len + 1] = (crc >> 8) & 0xff;
+}
+
+#if DEBUG_EEPROM
+void dump_cur_state(void)
+{
+  char buf[9];
+
+  sprintf(buf, BYTETOBINARYPATTERN, BYTETOBINARY(state));
+  Serial.print(F("State: "));
+  Serial.print(buf);
+  Serial.println();
+  Serial.print(F("IP: "));
+  ether.printIp(target_ip);
+  Serial.println();
+}
+
+void dump_buf(const uint8_t *data, int len)
+{
+  int i;
+  char buf[4];
+
+  for (i = 0; i < len; i++) {
+    sprintf(buf, "%02x ", data[i]);
+    Serial.print(buf);
+  }
+  Serial.println();
+}
+#endif
+
+void saveStateToEeprom() {
+  int i;
+  uint8_t eeprom_cur[EEPROM_SIZE];
+  uint8_t eeprom_new[EEPROM_SIZE];
+
+  eeprom_new[STATE_ADDR] = state;
+  memcpy(&eeprom_new[TARGET_IP_ADDR], target_ip, TARGET_IP_SIZE);
+  crc_write(eeprom_new, EEPROM_DATA_SIZE);
+
+#if DEBUG_EEPROM
+  Serial.println(F("Saving to EEPROM:"));
+  dump_cur_state();
+  Serial.println("EEPROM new data:");
+  dump_buf(eeprom_new, EEPROM_SIZE);
+#endif
+
+  cli();
+  for (i = 0; i < EEPROM_SIZE; i++)
+    eeprom_cur[i] = EEPROM.read(i);
+  sei();
+
+#if DEBUG_EEPROM
+  Serial.println("EEPROM current data:");
+  dump_buf(eeprom_cur, EEPROM_SIZE);
+  Serial.print(F("Writing: < "));
+  for (i = 0; i < EEPROM_SIZE; i++) {
+    if (eeprom_new[i] != eeprom_cur[i]) {
+      Serial.print(i);
+      Serial.print(F(" "));
+    }
+  }
+  Serial.println(F(">"));
+#endif
+
+  cli();
+  for (i = 0; i < EEPROM_SIZE; i++)
+    if (eeprom_new[i] != eeprom_cur[i])
+      EEPROM.write(i, eeprom_new[i]);
   sei();
 }
 
 void readStateFromEeprom() {
+  int i;
+  uint8_t eeprom[EEPROM_SIZE];
+
   cli();
-  state = EEPROM.read(STATE_ADDR);
+  for (i = 0; i < EEPROM_SIZE; i++)
+    eeprom[i] = EEPROM.read(i);
   sei();
+
+#if DEBUG_EEPROM
+  Serial.println("EEPROM raw data:");
+  dump_buf(eeprom, EEPROM_SIZE);
+#endif
+
+  if (crc_calc(eeprom, EEPROM_SIZE)) {
+#if DEBUG_EEPROM
+    Serial.println(F("EEPROM read: CRC mismatch, loading defaults"));
+#endif
+    state = 0;
+    memcpy(target_ip, allOnes, sizeof(target_ip));
+  } else {
+#if DEBUG_EEPROM
+    Serial.println(F("EEPROM read: CRC OK..."));
+#endif
+    state = eeprom[STATE_ADDR];
+    memcpy(target_ip, &eeprom[TARGET_IP_ADDR], sizeof(target_ip));
+  }
+
+#if DEBUG_EEPROM
+    Serial.println(F("EEPROM load results:"));
+    dump_cur_state();
+#endif
+
   sync_leds();
 }

--- a/client_firmware/sniffer.ino
+++ b/client_firmware/sniffer.ino
@@ -22,6 +22,7 @@ void packet_sniffer_callback(const uint8_t *src_mac, const uint8_t *src_ip) {
       ether.printIp(src_ip);
       Serial.println();
       memcpy(target_ip, src_ip, 4);
+      saveStateToEeprom();
     }
   }
 


### PR DESCRIPTION
Store target_ip in the EEPROM, so that when the system reboots, it doesn't forget the IP it was watching.

Enable broadcast/multicast reception, so that there's more chance of passively observing the target device.

Don't ping the target if we've seen traffic from it recently.

These tweaks have been running on my system for quite a while without any apparent issue (module that I just replaced the CRC algorithm tonight).
